### PR TITLE
チーム情報の操作に関しての機能を整えること

### DIFF
--- a/app/controllers/assigns_controller.rb
+++ b/app/controllers/assigns_controller.rb
@@ -27,7 +27,9 @@ class AssignsController < ApplicationController
   end
 
   def assign_destroy(assign, assigned_user)
-    if assigned_user == assign.team.owner
+    if !(assign.team.owner == current_user || assigned_user == current_user)
+      I18n.t('views.messages.cannot_delete_only_owner_or_self')
+    elsif assigned_user == assign.team.owner
       I18n.t('views.messages.cannot_delete_the_leader')
     elsif Assign.where(user_id: assigned_user.id).count == 1
       I18n.t('views.messages.cannot_delete_only_a_member')

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -15,7 +15,10 @@ class TeamsController < ApplicationController
     @team = Team.new
   end
 
-  def edit; end
+  def edit
+    if current_user.id == @team.owner_id
+    end
+  end
 
   def create
     @team = Team.new(team_params)
@@ -30,11 +33,11 @@ class TeamsController < ApplicationController
   end
 
   def update
-    if @team.update(team_params)
+    if current_user.id == @team.owner_id
+      @team.update(team_params)
       redirect_to @team, notice: I18n.t('views.messages.update_team')
     else
-      flash.now[:error] = I18n.t('views.messages.failed_to_save_team')
-      render :edit
+      redirect_to @team, notice: "権限がありません"
     end
   end
 

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -10,7 +10,9 @@
               <%= image_tag default_img(@team.icon_url), class: 'img' %><br>
               <%= @team.name %>
             </div>
-            <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% if current_user.id == @team.owner_id %>
+              <%= link_to I18n.t('views.messages.edit_team'), edit_team_path(@team), class: 'btn btn-success btn-block mt-3' %>
+            <% end %>
           </div>
 
           <div class="col-md-8">
@@ -41,7 +43,9 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% if current_user.id == @team.owner_id || current_user.id == assign.user_id %>
+                        <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -214,6 +214,7 @@ ja:
       does_not_exist_email: 'メールアドレスが存在しません。アカウントを作成してください。'
       cannot_delete_the_leader: 'リーダーは削除できません。'
       cannot_delete_only_a_member: 'このユーザーはこのチームにしか所属していないため、削除できません。'
+      cannot_delete_only_owner_or_self: 'このユーザーはオーナーかユーザー自身ではないため、削除できません。'
       delete_member: 'メンバーを削除しました。'
       cannot_delete_member_4_some_reason: 'なんらかの原因で、削除できませんでした。'
       failed_to_post: '投稿できませんでした...'


### PR DESCRIPTION
現状では、

そのTeamに所属しているUserの削除（離脱）が、どのUserでもできる
TeamのeditをTeamのリーダー（オーナー）以外でも自由にできる

という仕様になっているが、これを、

Teamに所属しているUserの削除（離脱）は、そのTeamのオーナーか、そのUser自身しかできないようにすること
TeamのeditはTeamのリーダー（オーナー）のみができるようにすること

という仕様に変更すること